### PR TITLE
Basic tracing instrumentation

### DIFF
--- a/embed-server/Cargo.toml
+++ b/embed-server/Cargo.toml
@@ -11,9 +11,18 @@ authors = ["Nova <novacrazy@gmail.com>"]
 common = { package = "client-sdk-common", git = "https://github.com/Lantern-chat/client-sdk-rs" }
 embed = { package = "embed-sdk", path = "../embed-sdk" }
 
-reqwest = { version = "0.11", default_features = false, features = ["rustls-tls", "json", "gzip", "brotli", "deflate"] }
+reqwest = { version = "0.11", default_features = false, features = [
+    "rustls-tls",
+    "json",
+    "gzip",
+    "brotli",
+    "deflate",
+] }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.6", features = ["http2"] }
+tower-http = { version = "0.4", features = ["trace"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 hashbrown = { version = "0.13", features = ["inline-more", "serde"] }
 iso8601-timestamp = "0.2"
@@ -45,10 +54,14 @@ serde_repr = "0.1.7"
 regex-automata = { version = "0.1.10", default_features = false }
 smallvec = "1.7.0"
 bitflags = "1.3.2"
-csscolorparser = { version = "0.6.2", default_features = false, features = ["named-colors"] }
+csscolorparser = { version = "0.6.2", default_features = false, features = [
+    "named-colors",
+] }
 html-escape = { version = "0.2.13", default_features = false }
 feed-rs = "1.3.0"
 
 regex-build = { git = "https://github.com/Lantern-chat/regex-build" }
 [build-dependencies]
-regex-build = { git = "https://github.com/Lantern-chat/regex-build", features = ["build"] }
+regex-build = { git = "https://github.com/Lantern-chat/regex-build", features = [
+    "build",
+] }

--- a/embed-server/Cargo.toml
+++ b/embed-server/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { version = "0.11", default_features = false, features = [
 ] }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.6", features = ["http2"] }
-tower-http = { version = "0.4", features = ["trace"] }
+tower-http = { version = "0.4", features = ["catch-panic", "trace"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/embed-server/src/extractors/deviantart.rs
+++ b/embed-server/src/extractors/deviantart.rs
@@ -20,6 +20,7 @@ impl Extractor for DeviantArtExtractor {
         }
     }
 
+    #[instrument(skip_all)]
     async fn extract(
         &self,
         state: Arc<ServiceState>,

--- a/embed-server/src/extractors/e621/mod.rs
+++ b/embed-server/src/extractors/e621/mod.rs
@@ -35,6 +35,7 @@ impl Extractor for E621Extractor {
         matches!(url.domain(), Some("e621.net" | "e926.net")) && url.path().starts_with("/posts/")
     }
 
+    #[instrument(skip_all)]
     async fn extract(
         &self,
         state: Arc<ServiceState>,
@@ -85,6 +86,7 @@ pub mod models;
 use models::*;
 
 #[allow(clippy::field_reassign_with_default)]
+#[instrument(skip(extractor, state))]
 async fn fetch_single_id(
     extractor: &E621Extractor,
     state: Arc<ServiceState>,

--- a/embed-server/src/extractors/furaffinity.rs
+++ b/embed-server/src/extractors/furaffinity.rs
@@ -58,6 +58,7 @@ impl Extractor for FurAffinityExtractor {
         ) && url.path().starts_with("/view/")
     }
 
+    #[instrument(skip_all)]
     async fn extract(
         &self,
         state: Arc<ServiceState>,
@@ -100,6 +101,7 @@ fn accumulate_text(el: ElementRef) -> String {
     })
 }
 
+#[instrument(skip_all)]
 fn parse_html(html: &str, url: &Url) -> Result<EmbedV1, Error> {
     let doc = scraper::Html::parse_document(html);
 

--- a/embed-server/src/extractors/generic.rs
+++ b/embed-server/src/extractors/generic.rs
@@ -15,6 +15,7 @@ impl Extractor for GenericExtractor {
         true
     }
 
+    #[instrument(skip_all)]
     async fn extract(
         &self,
         state: Arc<ServiceState>,

--- a/embed-server/src/extractors/imgur.rs
+++ b/embed-server/src/extractors/imgur.rs
@@ -62,6 +62,7 @@ impl Extractor for ImgurExtractor {
             .all(|c| c.is_ascii_alphanumeric())
     }
 
+    #[instrument(skip_all)]
     async fn extract(
         &self,
         state: Arc<ServiceState>,

--- a/embed-server/src/extractors/inkbunny.rs
+++ b/embed-server/src/extractors/inkbunny.rs
@@ -90,6 +90,7 @@ impl Extractor for InkbunnyExtractor {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     async fn extract(
         &self,
         state: Arc<ServiceState>,

--- a/embed-server/src/extractors/wikipedia.rs
+++ b/embed-server/src/extractors/wikipedia.rs
@@ -53,6 +53,7 @@ impl Extractor for WikipediaExtractor {
             && url.path().starts_with("/wiki/")
     }
 
+    #[instrument(skip_all)]
     async fn extract(
         &self,
         state: Arc<ServiceState>,

--- a/embed-server/src/main.rs
+++ b/embed-server/src/main.rs
@@ -31,7 +31,7 @@ use axum::{
 };
 use futures_util::FutureExt;
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
-use tower_http::trace::TraceLayer;
+use tower_http::{catch_panic::CatchPanicLayer, trace::TraceLayer};
 
 #[tokio::main]
 async fn main() {
@@ -77,6 +77,7 @@ async fn main() {
     axum::Server::bind(&addr)
         .serve(
             post(root)
+                .route_layer(CatchPanicLayer::new())
                 .with_state(state)
                 .layer(TraceLayer::new_for_http())
                 .into_make_service(),


### PR DESCRIPTION
This PR installs the basic fmt subscriber and adds some `instrument` annotations to add some more context to spans and installs the `TraceLayer`.  
It also adds the `CatchPanicLayer` to the route to output panic information via tracing and it prevents the panics from affecting any other open connections 