### PR TITLE
Move `EmbedWithExpire` alias to `embed-sdk`

### DIFF
--- a/embed-sdk/src/lib.rs
+++ b/embed-sdk/src/lib.rs
@@ -15,6 +15,11 @@ pub use thin_vec::ThinVec as MaybeThinVec;
 #[cfg(not(feature = "thin-vec"))]
 pub type MaybeThinVec<T> = alloc::vec::Vec<T>;
 
+/// Default type returned by the embed server
+///
+/// You probably want to deserialise the payloads with this type alias
+pub type EmbedWithExpire = (Timestamp, Embed);
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "v")]

--- a/embed-server/src/extractors/mod.rs
+++ b/embed-server/src/extractors/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use url::Url;
 
-pub type EmbedWithExpire = (iso8601_timestamp::Timestamp, embed::Embed);
+pub use embed::EmbedWithExpire;
 
 pub trait ExtractorFactory {
     fn create(&self, config: &Config) -> Result<Option<Box<dyn Extractor>>, ConfigError>;


### PR DESCRIPTION
This PR moves the `EmbedWithExpire` type to the `embed-sdk` crate and adds the note that this is the type returned by the embed server