### PR TITLE
Apply default clippy lint, run rustfmt

### DIFF
--- a/embed-server/src/extractors/e621/mod.rs
+++ b/embed-server/src/extractors/e621/mod.rs
@@ -6,7 +6,12 @@ pub struct E621ExtractorFactory;
 
 impl ExtractorFactory for E621ExtractorFactory {
     fn create(&self, config: &Config) -> Result<Option<Box<dyn Extractor>>, ConfigError> {
-        let Some(extractor) = config.parsed.extractors.get("e621").or_else(|| config.parsed.extractors.get("e926")) else {
+        let Some(extractor) = config
+            .parsed
+            .extractors
+            .get("e621")
+            .or_else(|| config.parsed.extractors.get("e926"))
+        else {
             return Ok(None);
         };
 
@@ -198,7 +203,11 @@ async fn fetch_single_id(
             break 'vid_alt;
         };
 
-        let Some(Some(url)) = alt.urls.iter().find(|&url| matches!(url, Some(url) if !url.ends_with("webm"))) else {
+        let Some(Some(url)) = alt
+            .urls
+            .iter()
+            .find(|&url| matches!(url, Some(url) if !url.ends_with("webm")))
+        else {
             break 'vid_alt;
         };
 

--- a/embed-server/src/extractors/furaffinity.rs
+++ b/embed-server/src/extractors/furaffinity.rs
@@ -29,7 +29,9 @@ impl ExtractorFactory for FurAffinityExtractorFactory {
         };
 
         let Some(ua) = config.parsed.user_agents.get("%browser") else {
-            return Err(ConfigError::InvalidUserAgent("%browser not found".to_owned()));
+            return Err(ConfigError::InvalidUserAgent(
+                "%browser not found".to_owned(),
+            ));
         };
 
         let Ok(cookie) = HeaderValue::try_from(format!("b={b}; a={a}")) else {
@@ -122,7 +124,9 @@ fn parse_html(html: &str, url: &Url) -> Result<EmbedV1, Error> {
         let mut kind = Kind::Unsupported;
 
         for e in node.traverse() {
-            let Edge::Open(node) = e else { continue; };
+            let Edge::Open(node) = e else {
+                continue;
+            };
             if let Node::Element(el) = node.value() {
                 kind = match el.name() {
                     "img" => Kind::Image,
@@ -165,7 +169,9 @@ fn parse_html(html: &str, url: &Url) -> Result<EmbedV1, Error> {
         let mut description = String::new();
 
         for e in node.traverse() {
-            let Edge::Open(node) = e else { continue; };
+            let Edge::Open(node) = e else {
+                continue;
+            };
             description += match node.value() {
                 Node::Text(t) => trim_nl(t).trim_start(),
                 Node::Element(el) => match el.name() {

--- a/embed-server/src/extractors/imgur.rs
+++ b/embed-server/src/extractors/imgur.rs
@@ -96,7 +96,11 @@ impl Extractor for ImgurExtractor {
             .json()
             .await?;
 
-        let ImgurResult::Success { data: Some(mut data), .. } = resp else {
+        let ImgurResult::Success {
+            data: Some(mut data),
+            ..
+        } = resp
+        else {
             return Err(Error::Failure(StatusCode::NOT_FOUND));
         };
 

--- a/embed-server/src/extractors/inkbunny.rs
+++ b/embed-server/src/extractors/inkbunny.rs
@@ -113,7 +113,10 @@ impl Extractor for InkbunnyExtractor {
 
         let resp = state.client.get(api_uri).send().await?.json().await?;
 
-        let InkbunnyResult::Success { submissions: [mut submission] } = resp else {
+        let InkbunnyResult::Success {
+            submissions: [mut submission],
+        } = resp
+        else {
             return Err(Error::Failure(StatusCode::NOT_FOUND));
         };
 

--- a/embed-server/src/extractors/wikipedia.rs
+++ b/embed-server/src/extractors/wikipedia.rs
@@ -83,7 +83,7 @@ impl Extractor for WikipediaExtractor {
 
         let mut embed = EmbedV1::default();
 
-        if let Some(TextPage::Found { title, extract }) = text.query.pages.get(0) {
+        if let Some(TextPage::Found { title, extract }) = text.query.pages.first() {
             embed.title = Some(title.clone());
             embed.description = Some(extract.into());
         } else {

--- a/embed-server/src/parser/oembed.rs
+++ b/embed-server/src/parser/oembed.rs
@@ -36,7 +36,7 @@ pub fn parse_link_header(header: &str) -> LinkList {
         //while let Some(part) = parts.next() {
         for part in parts {
             let Some((left, right)) = part.split_once('=') else {
-                continue 'links
+                continue 'links;
             };
 
             if left == "type" && right.contains("xml") {


### PR DESCRIPTION
This PR changes the following things:

- Applies a default clippy lint `.get(0)` -> `.first()`
- Runs `rustfmt` over the codebase